### PR TITLE
Random item

### DIFF
--- a/pluginInfo.json
+++ b/pluginInfo.json
@@ -1,6 +1,6 @@
 {
 	"repoName": "show-on-demand",
-	"name": "Show On Demand",
+	"name": "Show On Demand-Edit",
 	"author": "Joe Harrison (joeharrison714), edited by 104Zero for randomization",
 	"description": "This allows the show to be started on demand via text message",
 	"homeURL": "https://github.com/104Zero/show-on-demand-plugin",

--- a/pluginInfo.json
+++ b/pluginInfo.json
@@ -1,5 +1,5 @@
 {
-	"repoName": "show-on-demand",
+	"repoName": "show-on-demand-edit",
 	"name": "Show On Demand-Edit",
 	"author": "Joe Harrison (joeharrison714), edited by 104Zero for randomization",
 	"description": "This allows the show to be started on demand via text message",

--- a/pluginInfo.json
+++ b/pluginInfo.json
@@ -1,17 +1,17 @@
 {
 	"repoName": "show-on-demand",
 	"name": "Show On Demand",
-	"author": "Joe Harrison (joeharrison714)",
+	"author": "Joe Harrison (joeharrison714), edited by 104Zero for randomization",
 	"description": "This allows the show to be started on demand via text message",
-	"homeURL": "https://github.com/joeharrison714/show-on-demand-plugin",
-	"srcURL": "https://github.com/joeharrison714/show-on-demand-plugin.git",
+	"homeURL": "https://github.com/104Zero/show-on-demand-plugin",
+	"srcURL": "https://github.com/104Zero/show-on-demand-plugin.git",
 	"bugURL": "https://github.com/joeharrison714/show-on-demand-plugin/issues",
 	"allowUpdates": 1,
 	"versions": [
 		{
 			"minFPPVersion": "4.0",
 			"maxFPPVersion": "0",
-			"branch": "master",
+			"branch": "RandomPlaylistItem",
 			"sha": "",
 			"dependencies": {
 			    "plugins": [

--- a/pluginInfo.json
+++ b/pluginInfo.json
@@ -11,7 +11,7 @@
 		{
 			"minFPPVersion": "4.0",
 			"maxFPPVersion": "0",
-			"branch": "RandomPlaylistItem",
+			"branch": "RandomItem",
 			"sha": "",
 			"dependencies": {
 			    "plugins": [

--- a/scripts/postStart.sh
+++ b/scripts/postStart.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/usr/bin/php /home/fpp/media/plugins/show-on-demand/show_on_demand_bg.php &
+/usr/bin/php /home/fpp/media/plugins/show-on-demand-edit/show_on_demand_bg.php &

--- a/show_on_demand.php
+++ b/show_on_demand.php
@@ -49,6 +49,12 @@ if (strlen(urldecode($pluginSettings['message_not_started']))<1){
 	$madeChange = true;
 }
 
+#Add code for addition of Random Playlist Item selection
+if (strlen(urldecode($pluginSettings['random_playlist_item']))<1){
+	WriteSettingToFile("random_playlist_item",urlencode("false"),$pluginName);
+	$madeChange = true;
+}
+
 if ($madeChange) {
 	$pluginSettings = parse_ini_file($pluginConfigFile);
 }
@@ -159,6 +165,17 @@ foreach(scandir($playlistDirectory) as $pFile)
 </td>
 </tr>
 
+
+<tr>
+	<th style="text-align: left">Select Random Item from Playlist</th>
+<td>
+<?		
+	//Code to show checkbox for selecting a random item from the playlist	
+	PrintSettingCheckbox("Pick Random Item From Playlist", "random_playlist_item", $restart = 1, $reboot = 0, "true", "false", $pluginName = $pluginName, $callbackName = "", $defaultValue = 0, $desc = "", $sData = Array());
+?>
+</td>
+</tr>
+	
 </table>
 
 

--- a/show_on_demand_bg.php
+++ b/show_on_demand_bg.php
@@ -12,6 +12,10 @@ $pluginSettings = parse_ini_file($pluginConfigFile);
 $sodEnabled = $pluginSettings['show_on_demand_enabled'];
 $sodEnabled = $sodEnabled == "true" ? true : false;
 
+#Add code to allow selection of a random item from the playlist
+$randomItemEnabled = $pluginSettings['random_playlist_item'];
+$randomItemEnabled = $randomItemEnabled  == "true" ? true : false;
+
 $api_base_path = "https://voip.ms/api/v1";
 $oldest_message_age = 180;
 
@@ -52,6 +56,9 @@ if($sodEnabled == 1) {
         if (strlen($startCommand)==0){
             throw new Exception('No start command specified.');
         }
+
+        #Add code to print if "random item" is selected
+        logEntry("Random Item " . $randomItemEnabled);
 
         logEntry("Success message: " . $messageSuccess);
         logEntry("Not-started message: " . $messageNotStarted);
@@ -116,9 +123,17 @@ if($sodEnabled == 1) {
 
 function startShow(){
     global $mainPlaylist;
-
+    global $randomItemEnabled;
     
-    $url = "http://127.0.0.1/api/command/Insert Playlist Immediate/" . $mainPlaylist ."/0/0/true";
+    #Code to adjust the API request depending on if random item is selected or not
+    if ($randomItemEnabled == 1){
+	    $url = "http://127.0.0.1/api/command/Insert Random Item From Playlist/" . $mainPlaylist ."/true";
+        logEntry("Selecting Random Item from Playlist");
+    }
+    else{	    
+        $url = "http://127.0.0.1/api/command/Insert Playlist Immediate/" . $mainPlaylist ."/0/0/true";
+    }
+	
     $url = str_replace(' ', '%20', $url);
 
     logEntry("Triggering main playlist: " . $url);


### PR DESCRIPTION
Hi Joe -- I added some edits to allow the selection of a random item from the show playlist.   This adds a checkbox into the plugin setup page, and when selected will only insert 1 random item from the given playlist, rather than playing the entire playlist.

I was having some issues with the naming when installing on my FPP, so I added "-edit" to several of the repo titles -- those should be ignored.